### PR TITLE
FIX configurationDir on OS X HFS+ file system (case insensitive)

### DIFF
--- a/lib/Util/Configuration/ClassConfigurationReader.php
+++ b/lib/Util/Configuration/ClassConfigurationReader.php
@@ -46,12 +46,15 @@ class ClassConfigurationReader
                 $filename = "{$path}/configuration";
                 $realpath = realpath($filename);
                 if ($realpath !== false && is_dir($realpath)) {
-                    $parts = explode(DIRECTORY_SEPARATOR, $realpath);
-                    $lastPart = array_pop($parts);
-                    // The equality check is due to case-insensitive file systems *ahem* Windows
-                    if ($lastPart == 'configuration') {
-                        $configurationDir = $realpath;
-                        break;
+                    // The equality check is due to case-insensitive file systems *ahem* Windows and OS X HFS+
+                    $directories = glob(realpath($filename.'/../').'/*', GLOB_ONLYDIR);
+                    foreach ($directories as $directory) {
+                        $parts = explode(DIRECTORY_SEPARATOR, $directory);
+                        $lastPart = array_pop($parts);
+                        if ($lastPart == 'configuration') {
+                            $configurationDir = $realpath;
+                            break;
+                        }
                     }
                 }
                 $path .= '/../';


### PR DESCRIPTION
1.) Issue "Configuration not loaded" is due to the (semi) case INsensitivity of OS X's HFS+ file system. 
The current code tries to load configurations from: vendor/magium/magium/lib/Util/configuration

2.) realpath() on MacOSX doesn't normalize the case of characters
https://bugs.php.net/bug.php?id=67220
So using glob on the current parent directory is a workaround. Don't know if it is a good idea.